### PR TITLE
Updated README to reflect current location of plotly R package

### DIFF
--- a/README.org
+++ b/README.org
@@ -8,7 +8,7 @@ uploaded to plotly using library(ggplotly).
 #+BEGIN_SRC R
 install.packages("devtools")
 library(devtools)
-install_github("R-api", "plotly")
+install_github("plotly", "ropensci")
 install_github("ggplotly", "tdhock")
 library(ggplotly)
 example(ggplotly)


### PR DESCRIPTION
Hi there,
The `plotly` package has now become part of the [rOpenSci](https://github.com/ropensci/plotly) project. So I've updated the install location in your readme.
